### PR TITLE
Update README.md: Add link to google document

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # human-data-local-ega
 Local EGA
+
+* [Google Docuement with setup instruction](https://docs.google.com/document/d/1bBLcfVfOohat8Eg-7FK3MqC0LDG5QQ_B_7V73_vkpbc/edit)


### PR DESCRIPTION
Hi, would be great to have the google doc link in context, right in the README!

(Even better to have the full instructions in the README, but a link is a good start)
